### PR TITLE
Hint to use RadioLib instead for SX1262 and SX1268

### DIFF
--- a/examples/ArduinoLoRa/LoRaReceiver/utilities.h
+++ b/examples/ArduinoLoRa/LoRaReceiver/utilities.h
@@ -3,6 +3,7 @@
 
 /*
 * arduinoLoRa Library just only support SX1276/Sx1278,Not support SX1262
+* RadioLib Library supports also SX1262/SX1268 see https://github.com/Xinyuan-LilyGO/LilyGo-LoRa-Series/tree/master/examples/RadioLibExamples
 * */
 // #define LILYGO_TBeam_V0_7
 // #define LILYGO_TBeam_V1_0

--- a/examples/ArduinoLoRa/LoRaSender/utilities.h
+++ b/examples/ArduinoLoRa/LoRaSender/utilities.h
@@ -3,6 +3,7 @@
 
 /*
 * arduinoLoRa Library just only support SX1276/Sx1278,Not support SX1262
+* RadioLib Library supports also SX1262/SX1268 see https://github.com/Xinyuan-LilyGO/LilyGo-LoRa-Series/tree/master/examples/RadioLibExamples
 * */
 // #define LILYGO_TBeam_V0_7
 // #define LILYGO_TBeam_V1_0


### PR DESCRIPTION
Users potential get stuck with SX1262/SX1268 versions when trying out the ArduinoLoRa library. Update the comment in the ArduinoLoRa example to make it obviously to use the RadioLib library instead.